### PR TITLE
GPS-INS Localizer

### DIFF
--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/CMakeLists.txt
@@ -6,7 +6,6 @@ set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra ${CMAKE_CXX_FLAGS}")
 
 set(catkin_deps roscpp roslib nodelet tf2 tf2_ros novatel_gps_msgs sensor_msgs geometry_msgs roslint)
 find_package(catkin REQUIRED ${catkin_deps})
-find_package(GeographicLib REQUIRED)
 
 catkin_package(
     INCLUDE_DIRS include
@@ -34,7 +33,7 @@ add_library(${PROJECT_NAME}_nodelet
 
 target_link_libraries(${PROJECT_NAME}_nodelet
     ${catkin_LIBRARIES}
-    GeographicLib
+    libGeographic.so
 )
 
 # node

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/CMakeLists.txt
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(gpsins_localizer)
+
+## c++11 feature
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra ${CMAKE_CXX_FLAGS}")
+
+set(catkin_deps roscpp roslib nodelet tf2 tf2_ros novatel_gps_msgs sensor_msgs geometry_msgs roslint)
+find_package(catkin REQUIRED ${catkin_deps})
+find_package(GeographicLib REQUIRED)
+
+catkin_package(
+    INCLUDE_DIRS include
+    CATKIN_DEPENDS ${catkin_deps}
+    LIBRARIES ${PROJECT_NAME} ${PROJECT_NAME}_nodelet
+)
+
+roslint_cpp()
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+)
+
+# nodelet
+add_library(${PROJECT_NAME}_nodelet
+    src/${PROJECT_NAME}_nodelet.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}_nodelet
+    ${catkin_LIBRARIES}
+    GeographicLib
+)
+
+# node
+add_executable(${PROJECT_NAME}_node
+    src/gpsins_localizer_node.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}_node
+    ${catkin_LIBRARIES}
+)
+
+##########
+## TEST ##
+##########
+
+if (CATKIN_ENABLE_TESTING)
+    find_package(rostest REQUIRED)
+
+    # ROS tests
+    add_rostest_gtest(test_${PROJECT_NAME}_node
+        test/rostest_launch.test
+        test/rostest_integration_test.cpp
+    )
+    target_link_libraries(test_${PROJECT_NAME}_node
+        ${catkin_LIBRARIES}
+    )
+endif(CATKIN_ENABLE_TESTING)
+
+#############
+## Install ##
+#############
+
+install(TARGETS ${PROJECT_NAME}_node ${PROJECT_NAME}_nodelet
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(DIRECTORY launch config
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+install(FILES nodelets.xml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/LICENSE
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019 AutonomouStuff, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/README.md
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/README.md
@@ -1,0 +1,48 @@
+# gpsins_localizer
+
+This ROS package is for providing a localization solution that relies only on
+GPS-INS data. An example of a GPS-INS system that provides this data is the
+[Novatel SPAN](https://www.novatel.com/products/span-gnss-inertial-systems/)
+system. Currently, this package depends on the
+[`novatel_gps_msgs/inspva`](https://github.com/swri-robotics/novatel_gps_driver/blob/master/novatel_gps_msgs/msg/Inspva.msg)
+message, however it should be easy enough to add support for other
+device-specific message types.
+
+## ROS API
+
+#### Subs
+
+- `inspva` ([novatel_gps_msgs/Inspva](https://github.com/swri-robotics/novatel_gps_driver/blob/master/novatel_gps_msgs/msg/Inspva.msg))  
+This topic is used to calculate vehicle Pose in the map frame, as well as a forward velocity estimate.
+- `imu`([sensor_msgs/Imu](http://docs.ros.org/melodic/api/sensor_msgs/html/msg/Imu.html))  
+This topic is used to populate the angular velocities of the vehicle state.
+
+#### Pubs
+
+- `current_pose` ([geometry_msgs/PoseStamped](http://docs.ros.org/api/geometry_msgs/html/msg/PoseStamped.html))  
+For use with autoware
+- `current_velocity` ([geometry_msgs/TwistStamped](http://docs.ros.org/api/geometry_msgs/html/msg/TwistStamped.html))  
+For use with autoware
+
+#### Transform Listeners
+
+- `earth` -> `map` static TF [optional]  
+This tf is required in order to transform GPS coordinates into an existing map frame. If the map frame doesn't already exist, set the `create_map_frame` param to `true`.
+- `base_link` -> `gps` static TF  
+Required to calculate the offset between the gps-ins sensor mount location and the `base_link`.
+
+#### Transform Broadcasters
+
+- `map` -> `base_link`  
+The updated pose of the vehicle
+- `earth` -> `gps_measured` [optional]  
+The pose of the gps-ins sensor in the earth frame.
+
+#### Configuration Parameters
+
+See the `config/params.yaml` file for a list of parameters and their descriptions.
+
+## Notes
+
+- This package assumes that the imu is mounted close enough to the base_link so that the angular velocity measurements from the imu are considered the angular velocities of the base_link.
+- It is assumed that the gps-ins roll/pitch orientation data follows a y-forward, z-up coordinate frame as shown [here](https://docs.novatel.com/OEM7/Content/Resources/Images/Vehicle%20Body%20Frame%20Airplane_372x378.png).

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/README.md
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/README.md
@@ -8,6 +8,11 @@ system. Currently, this package depends on the
 message, however it should be easy enough to add support for other
 device-specific message types.
 
+## Dependencies
+
+- [GeogrpahicLib](https://sourceforge.net/projects/geographiclib/). Can be installed via apt (`libgeographic-dev`) or from rosdep (`geographiclib`).
+- [novatel_gps_msgs](https://github.com/swri-robotics/novatel_gps_driver/blob/master/novatel_gps_msgs). Can be installed via apt (`ros-kinetic-novatel-gps-msgs`) or rosdep (`novatel_gps_msgs`).
+
 ## ROS API
 
 #### Subs

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
@@ -1,0 +1,18 @@
+# Topic name for imu data
+imu_data_topic_name: gps/imu
+
+# Topic name for inspva data
+ins_data_topic_name: gps/inspva
+
+# Enable this to "plant" the origin of the map frame at the first received LLH
+# position. If an existing map frame is defined, this should not be set.
+create_map_frame: true
+
+# Enable if you want to directly publish the measured earth -> gps TF
+publish_earth_gpsm_tf: true
+# The name of the measured GPS frame
+measured_gps_frame: gps_measured
+
+# The frame name of the gps sensor, Novatel SPAN devices report data in the imu
+# frame
+static_gps_frame: imu

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
@@ -1,0 +1,100 @@
+/*
+* AutonomouStuff ("COMPANY") CONFIDENTIAL
+* Unpublished Copyright (c) 2009-2019 AutonomouStuff, All Rights Reserved.
+*
+* NOTICE:  All information contained herein is, and remains the property of COMPANY. The intellectual and technical concepts contained
+* herein are proprietary to COMPANY and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law.
+* Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained
+* from COMPANY.  Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees, managers or contractors who have executed
+* Confidentiality and Non-disclosure agreements explicitly covering such access.
+*
+* The copyright notice above does not evidence any actual or intended publication or disclosure  of  this source code, which includes
+* information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.   ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
+* OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT  THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE
+* LAWS AND INTERNATIONAL TREATIES.  THE RECEIPT OR POSSESSION OF  THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS
+* TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+*/
+
+#ifndef GPSINS_LOCALIZER_GPSINSLOCALIZERNL_H
+#define GPSINS_LOCALIZER_GPSINSLOCALIZERNL_H
+
+#include <ros/ros.h>
+#include <ros/package.h>
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_ros/buffer.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+
+#include <novatel_gps_msgs/Inspva.h>
+#include <sensor_msgs/Imu.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <geometry_msgs/Point.h>
+
+typedef message_filters::sync_policies::ApproximateTime<novatel_gps_msgs::Inspva, sensor_msgs::Imu> MySyncPolicy;
+
+namespace gpsins_localizer {
+
+class GpsInsLocalizerNl : public nodelet::Nodelet {
+ public:
+    GpsInsLocalizerNl();
+
+ private:
+    // Init
+    virtual void onInit();
+    void loadParams();
+
+    // Subscriber callbacks
+    void insDataCb(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg,
+        const sensor_msgs::Imu::ConstPtr& imu_msg);
+
+    // Util functions
+    void pubishVelocity(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg,
+        const sensor_msgs::Imu::ConstPtr& imu_msg);
+    void createMapFrame(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg);
+    void bcMeasuredGpsFrame(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg);
+    void checkInitialize(std::string ins_status);
+    tf2::Transform convertLLHtoECEF(double latitude, double longitude, double height);
+    tf2::Quaternion convertAzimuthToENU(double roll, double pitch, double yaw);
+
+    // Nodehandles, both public and private
+    ros::NodeHandle nh, pnh;
+
+    // Publishers
+    ros::Publisher pose_pub;
+    ros::Publisher velocity_pub;
+    tf2_ros::TransformBroadcaster tf_bc;
+    tf2_ros::StaticTransformBroadcaster stf_bc;
+
+    // Subscribers
+    message_filters::Subscriber<novatel_gps_msgs::Inspva> inspva_sub;
+    message_filters::Subscriber<sensor_msgs::Imu> imu_sub;
+    message_filters::Synchronizer<MySyncPolicy>* sync;
+    tf2_ros::Buffer tf_buffer;
+    tf2_ros::TransformListener tf_listener;
+
+    // Static transforms
+    tf2::Transform earth_map_tf;
+    tf2::Transform base_link_gps_tf;
+
+    // Internal state
+    bool initialized = false;
+    bool map_frame_established = false;
+    bool gps_frame_established = false;
+
+    // Parameters
+    std::string imu_data_topic_name = "gps/imu";
+    std::string ins_data_topic_name = "gps/inspva";
+    bool create_map_frame = false;
+    bool publish_earth_gpsm_tf = false;
+    std::string measured_gps_frame = "gps_measured";
+    std::string static_gps_frame = "gps";
+};
+
+}  // namespace gpsins_localizer
+#endif  // GPSINS_LOCALIZER_GPSINSLOCALIZERNL_H

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
@@ -1,18 +1,8 @@
 /*
-* AutonomouStuff ("COMPANY") CONFIDENTIAL
 * Unpublished Copyright (c) 2009-2019 AutonomouStuff, All Rights Reserved.
 *
-* NOTICE:  All information contained herein is, and remains the property of COMPANY. The intellectual and technical concepts contained
-* herein are proprietary to COMPANY and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law.
-* Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained
-* from COMPANY.  Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees, managers or contractors who have executed
-* Confidentiality and Non-disclosure agreements explicitly covering such access.
-*
-* The copyright notice above does not evidence any actual or intended publication or disclosure  of  this source code, which includes
-* information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.   ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
-* OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT  THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE
-* LAWS AND INTERNATIONAL TREATIES.  THE RECEIPT OR POSSESSION OF  THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS
-* TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+* This file is part of the gpsins_localizer which is released under the MIT license.
+* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
 */
 
 #ifndef GPSINS_LOCALIZER_GPSINSLOCALIZERNL_H

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/gpsins_localizer_node.launch
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/gpsins_localizer_node.launch
@@ -1,0 +1,5 @@
+<launch>
+    <node pkg="gpsins_localizer" type="gpsins_localizer_node" name="gpsins_localizer" output="screen">
+        <rosparam command="load" file="$(find gpsins_localizer)/config/params.yaml" />
+    </node>
+</launch>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/lgsvl_simulation.launch
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/lgsvl_simulation.launch
@@ -1,0 +1,8 @@
+<launch>
+    <node pkg="gpsins_localizer" type="gpsins_localizer_node" name="gpsins_localizer" output="screen">
+        <rosparam command="load" file="$(find gpsins_localizer)/config/params.yaml" />
+        <param name="imu_data_topic_name" value="/imu_raw" />
+    </node>
+
+    <node pkg="tf2_ros" type="static_transform_publisher" name="imu_mounting_position" args="0.1 0 0.2 0 0 0 base_link imu"/>
+</launch>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/map_frame_example.launch
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/map_frame_example.launch
@@ -1,0 +1,7 @@
+<launch>
+    <!-- Define the transform from the earth to map frame -->
+    <node pkg="tf2_ros" type="static_transform_publisher" name="earth_to_map" args="
+        43723.6329509 -4848708.00123 4129913.74804
+        0.417769295288 0.0018835966194 0.00409634355235 0.908541957175
+        earth map" />
+</launch>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/nodelets.xml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/nodelets.xml
@@ -1,0 +1,9 @@
+<library path="lib/libgpsins_localizer_nodelet">
+    <class name="gpsins_localizer/gpsins_localizer_nodelet"
+           type="gpsins_localizer::GpsInsLocalizerNl"
+           base_class_type="nodelet::Nodelet">
+        <description>
+           Localization module based on GPS-INS data
+        </description>
+    </class>
+</library>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/package.xml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/package.xml
@@ -1,0 +1,23 @@
+<package format="2">
+    <name>gpsins_localizer</name>
+    <version>0.0.1</version>
+    <description>Localization module based on GPS-INS data</description>
+    <author email="icolwell@autonomoustuff.com">Ian Colwell</author>
+    <maintainer email="icolwell@autonomoustuff.com">Ian Colwell</maintainer>
+    <license>TODO</license>
+
+    <buildtool_depend>catkin</buildtool_depend>
+    <depend>roscpp</depend>
+    <depend>roslib</depend>
+    <depend>nodelet</depend>
+    <depend>tf2</depend>
+    <depend>tf2_ros</depend>
+    <depend>novatel_gps_msgs</depend>
+    <depend>sensor_msgs</depend>
+    <depend>geometry_msgs</depend>
+    <depend>roslint</depend>
+
+    <export>
+        <nodelet plugin="${prefix}/nodelets.xml"/>
+    </export>
+</package>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/package.xml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/package.xml
@@ -9,6 +9,7 @@
     <buildtool_depend>catkin</buildtool_depend>
     <depend>roscpp</depend>
     <depend>roslib</depend>
+    <depend>geographiclib</depend>
     <depend>nodelet</depend>
     <depend>tf2</depend>
     <depend>tf2_ros</depend>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/scripts/lgsvl_converter.py
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/scripts/lgsvl_converter.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import roslib
+import rospy
+from sensor_msgs.msg import Imu
+from nmea_msgs.msg import Sentence
+from novatel_gps_msgs.msg import Inspva
+from nav_msgs.msg import Odometry
+
+gpgga = None
+velocity = None
+
+def odom_cb(data):
+    global velocity
+    velocity = float(data.twist.twist.linear.x)
+
+def nmea_cb(data):
+    global inspva_pub
+    global gpgga
+    global velocity
+
+    nmea_data = data.sentence.split(",")
+
+    if nmea_data[0] == '$GPGGA':
+        gpgga = nmea_data
+        return
+    elif nmea_data[0] == 'QQ02C':
+        qq02c = nmea_data
+    else:
+        return
+
+    if gpgga is None:
+        print("No gpgga")
+        return
+    if velocity is None:
+        print("No velocity")
+        return
+
+    # Combine GPGGA and QQ02C
+    msg = Inspva();
+    msg.header.stamp = data.header.stamp
+    msg.status = "INS_SOLUTION_GOOD"
+    msg.latitude = float(gpgga[2])
+    msg.longitude = float(gpgga[4])
+
+    # NOTE: this is wrong, we are using altitude instead of height because the
+    # LG simulator doesn't give us height
+    msg.height = float(gpgga[9])
+    msg.roll = float(qq02c[4])
+    msg.pitch = float(qq02c[5])
+    msg.azimuth = float(qq02c[6])
+    msg.north_velocity = velocity
+    msg.east_velocity = 0.0
+    inspva_pub.publish(msg)
+
+def converter():
+
+    global inspva_pub
+    inspva_pub = rospy.Publisher("/gps/inspva", Inspva, queue_size=10)
+    rospy.Subscriber("/nmea_sentence", Sentence, nmea_cb)
+    rospy.Subscriber("/odom", Odometry, odom_cb)
+
+    rospy.spin()
+
+# Main function.
+if __name__ == '__main__':
+
+    # Initialize the node and name it.
+    rospy.init_node('lgsvl_converter').
+
+    converter()

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_node.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_node.cpp
@@ -1,0 +1,34 @@
+/*
+* AutonomouStuff ("COMPANY") CONFIDENTIAL
+* Unpublished Copyright (c) 2009-2019 AutonomouStuff, All Rights Reserved.
+*
+* NOTICE:  All information contained herein is, and remains the property of COMPANY. The intellectual and technical concepts contained
+* herein are proprietary to COMPANY and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law.
+* Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained
+* from COMPANY.  Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees, managers or contractors who have executed
+* Confidentiality and Non-disclosure agreements explicitly covering such access.
+*
+* The copyright notice above does not evidence any actual or intended publication or disclosure  of  this source code, which includes
+* information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.   ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
+* OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT  THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE
+* LAWS AND INTERNATIONAL TREATIES.  THE RECEIPT OR POSSESSION OF  THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS
+* TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+*/
+
+#include <ros/ros.h>
+#include <std_msgs/String.h>
+#include <nodelet/loader.h>
+#include <string>
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "gpsins_localizer_node");
+    nodelet::Loader nodelet;
+    nodelet::M_string remap(ros::names::getRemappings());
+    nodelet::V_string nargv;
+    std::string nodelet_name = ros::this_node::getName();
+    nodelet.load(
+      nodelet_name, "gpsins_localizer/gpsins_localizer_nodelet", remap, nargv);
+    ros::spin();
+    return 0;
+}

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_node.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_node.cpp
@@ -1,18 +1,8 @@
 /*
-* AutonomouStuff ("COMPANY") CONFIDENTIAL
 * Unpublished Copyright (c) 2009-2019 AutonomouStuff, All Rights Reserved.
 *
-* NOTICE:  All information contained herein is, and remains the property of COMPANY. The intellectual and technical concepts contained
-* herein are proprietary to COMPANY and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law.
-* Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained
-* from COMPANY.  Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees, managers or contractors who have executed
-* Confidentiality and Non-disclosure agreements explicitly covering such access.
-*
-* The copyright notice above does not evidence any actual or intended publication or disclosure  of  this source code, which includes
-* information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.   ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
-* OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT  THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE
-* LAWS AND INTERNATIONAL TREATIES.  THE RECEIPT OR POSSESSION OF  THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS
-* TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+* This file is part of the gpsins_localizer which is released under the MIT license.
+* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
 */
 
 #include <ros/ros.h>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
@@ -1,0 +1,316 @@
+/*
+* AutonomouStuff ("COMPANY") CONFIDENTIAL
+* Unpublished Copyright (c) 2009-2019 AutonomouStuff, All Rights Reserved.
+*
+* NOTICE:  All information contained herein is, and remains the property of COMPANY. The intellectual and technical concepts contained
+* herein are proprietary to COMPANY and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law.
+* Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained
+* from COMPANY.  Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees, managers or contractors who have executed
+* Confidentiality and Non-disclosure agreements explicitly covering such access.
+*
+* The copyright notice above does not evidence any actual or intended publication or disclosure  of  this source code, which includes
+* information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.   ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
+* OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT  THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE
+* LAWS AND INTERNATIONAL TREATIES.  THE RECEIPT OR POSSESSION OF  THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS
+* TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+*/
+
+#include "gpsins_localizer/gpsins_localizer_nodelet.hpp"
+
+#include <string>
+#include <vector>
+#include <math.h>
+#include <GeographicLib/Geocentric.hpp>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+namespace gpsins_localizer
+{
+
+GpsInsLocalizerNl::GpsInsLocalizerNl() :
+    tf_listener(this->tf_buffer)
+{}
+
+void GpsInsLocalizerNl::onInit()
+{
+    this->nh = getNodeHandle();
+    this->pnh = getPrivateNodeHandle();
+    this->loadParams();
+
+    // Publishers
+    this->pose_pub = nh.advertise<geometry_msgs::PoseStamped>("current_pose", 10);
+    this->velocity_pub = nh.advertise<geometry_msgs::TwistStamped>("current_velocity", 10);
+
+    // Subscribers
+    this->inspva_sub.subscribe(this->nh, this->ins_data_topic_name, 10);
+    this->imu_sub.subscribe(this->nh, this->imu_data_topic_name, 10);
+
+    this->sync = new message_filters::Synchronizer<MySyncPolicy>(MySyncPolicy(10), this->inspva_sub, this->imu_sub);
+    this->sync->registerCallback(boost::bind(&GpsInsLocalizerNl::insDataCb, this, _1, _2));
+}
+
+void GpsInsLocalizerNl::loadParams()
+{
+    this->pnh.param<std::string>("imu_data_topic_name", this->imu_data_topic_name, "gps/imu");
+    this->pnh.param<std::string>("ins_data_topic_name", this->ins_data_topic_name, "gps/inspva");
+    this->pnh.param("create_map_frame", this->create_map_frame, false);
+    this->pnh.param("publish_earth_gpsm_tf", this->publish_earth_gpsm_tf, false);
+    this->pnh.param<std::string>("measured_gps_frame", this->measured_gps_frame, "gps_measured");
+    this->pnh.param<std::string>("static_gps_frame", this->static_gps_frame, "gps");
+    ROS_INFO("Parameters Loaded");
+}
+
+void GpsInsLocalizerNl::insDataCb(
+    const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg,
+    const sensor_msgs::Imu::ConstPtr& imu_msg)
+{
+    // We don't need any static TFs for these 2 functions, so no need to wait
+    // for init
+    if (this->create_map_frame)
+    {
+        createMapFrame(inspva_msg);
+    }
+    if (this->publish_earth_gpsm_tf)
+    {
+        bcMeasuredGpsFrame(inspva_msg);
+    }
+
+    // Don't continue if uninitialized
+    checkInitialize(inspva_msg->status);
+    if (!this->initialized)
+    {
+        return;
+    }
+
+    // Get position of measured GPS coordinates in earth frame
+    tf2::Transform gps_point_earth = convertLLHtoECEF(
+        inspva_msg->latitude, inspva_msg->longitude, inspva_msg->height);
+
+    // Get position in map frame
+    tf2::Transform gps_pose_map = earth_map_tf * gps_point_earth;
+
+    // Orientation of the gps in the ENU(map) frame
+    tf2::Quaternion orientation_gps_map = convertAzimuthToENU(
+        inspva_msg->roll * M_PI / 180,
+        inspva_msg->pitch * M_PI / 180,
+        inspva_msg->azimuth * M_PI / 180);
+
+    // Completed Pose of the gps in the map frame
+    gps_pose_map.setRotation(orientation_gps_map);
+
+    // Pose of base_link in the map frame
+    tf2::Transform base_link_map = gps_pose_map * base_link_gps_tf;
+
+    // Broadcast the map -> base_link transform
+    geometry_msgs::TransformStamped map_baselink_tf;
+    map_baselink_tf.header.frame_id = "map";
+    map_baselink_tf.child_frame_id = "base_link";
+    map_baselink_tf.header.stamp = inspva_msg->header.stamp;
+    tf2::convert(base_link_map, map_baselink_tf.transform);
+    this->tf_bc.sendTransform(map_baselink_tf);
+
+    // Publish base_link pose in the map frame
+    geometry_msgs::PoseStamped base_link_map_stamped;
+    base_link_map_stamped.header.stamp = inspva_msg->header.stamp;
+    base_link_map_stamped.header.frame_id = "map";
+    tf2::toMsg(base_link_map, base_link_map_stamped.pose);
+    this->pose_pub.publish(base_link_map_stamped);
+
+    pubishVelocity(inspva_msg, imu_msg);
+    return;
+}
+
+void GpsInsLocalizerNl::pubishVelocity(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg,
+    const sensor_msgs::Imu::ConstPtr& imu_msg)
+{
+    // GPS velocity
+    double n_vel = inspva_msg->north_velocity;
+    double e_vel = inspva_msg->east_velocity;
+    double gps_velocity = sqrt(n_vel * n_vel + e_vel * e_vel);
+
+    // Publish Twist in the base_link frame
+    geometry_msgs::TwistStamped twist_bl;
+    twist_bl.header.stamp = inspva_msg->header.stamp;
+    twist_bl.header.frame_id = "base_link";
+    twist_bl.twist.linear.x = gps_velocity;
+    twist_bl.twist.linear.y = 0.0;
+    twist_bl.twist.linear.z = 0.0;
+    twist_bl.twist.angular.x = imu_msg->angular_velocity.x;
+    twist_bl.twist.angular.y = imu_msg->angular_velocity.y;
+    twist_bl.twist.angular.z = imu_msg->angular_velocity.z;
+    this->velocity_pub.publish(twist_bl);
+}
+
+void GpsInsLocalizerNl::createMapFrame(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg)
+{
+    tf2::Transform new_earth_map_tf = convertLLHtoECEF(
+        inspva_msg->latitude, inspva_msg->longitude, inspva_msg->height);
+
+    geometry_msgs::TransformStamped earth_map_tfs_msg;
+    earth_map_tfs_msg.header.stamp = inspva_msg->header.stamp;
+    earth_map_tfs_msg.header.frame_id = "earth";
+    earth_map_tfs_msg.child_frame_id = "map";
+    tf2::convert(new_earth_map_tf, earth_map_tfs_msg.transform);
+    this->stf_bc.sendTransform(earth_map_tfs_msg);
+    this->create_map_frame = false;
+
+    // Also save internally, no need to wait for tf listener
+    this->earth_map_tf = new_earth_map_tf.inverse();
+    this->map_frame_established = true;
+}
+
+void GpsInsLocalizerNl::bcMeasuredGpsFrame(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg)
+{
+    // Get ENU TF of measured GPS coordinates
+    tf2::Transform earth_gps_enu_tf = convertLLHtoECEF(
+        inspva_msg->latitude, inspva_msg->longitude, inspva_msg->height);
+
+    // Orientation of the gps in the ENU frame
+    tf2::Quaternion orientation_gpsm = convertAzimuthToENU(
+        inspva_msg->roll * M_PI / 180,
+        inspva_msg->pitch * M_PI / 180,
+        inspva_msg->azimuth * M_PI / 180);
+
+    // Pose of the gps in the temporary measured gps ENU frame
+    tf2::Transform tfpose_gpsm(orientation_gpsm);
+
+    // Pose of gps in earth frame, with proper orientation
+    tf2::Transform tfpose_earth = earth_gps_enu_tf * tfpose_gpsm;
+
+    // Convert and broadcast
+    geometry_msgs::TransformStamped output_tf2;
+    output_tf2.header.stamp = inspva_msg->header.stamp;
+    output_tf2.header.frame_id = "earth";
+    output_tf2.child_frame_id = this->measured_gps_frame;
+    tf2::convert(tfpose_earth, output_tf2.transform);
+
+    this->tf_bc.sendTransform(output_tf2);
+}
+
+void GpsInsLocalizerNl::checkInitialize(std::string ins_status)
+{
+    if (this->initialized)
+    {
+        return;
+    }
+
+    // First check for required transforms
+    // Check for earth -> map transform (Where is the map located in the world?)
+    if (!this->map_frame_established)
+    {
+        try
+        {
+            geometry_msgs::TransformStamped tf_msg =
+                this->tf_buffer.lookupTransform("map", "earth", ros::Time(0));
+            tf2::convert(tf_msg.transform, this->earth_map_tf);
+        }
+        catch (tf2::TransformException &ex)
+        {
+            ROS_WARN_THROTTLE(2, "%s", ex.what());
+            ROS_WARN_THROTTLE(2, "Waiting for earth -> map transform");
+            return;
+        }
+        this->map_frame_established = true;
+    }
+
+    // Check for base_link -> gps transform (Where is the gps sensor mounted on
+    // the vehicle?)
+    if (!this->gps_frame_established)
+    {
+        try
+        {
+            geometry_msgs::TransformStamped tf_msg =
+                this->tf_buffer.lookupTransform(this->static_gps_frame, "base_link", ros::Time(0));
+            tf2::convert(tf_msg.transform, this->base_link_gps_tf);
+        }
+        catch (tf2::TransformException &ex)
+        {
+            ROS_WARN_THROTTLE(2, "%s", ex.what());
+            ROS_WARN_THROTTLE(2, "Waiting for base_link -> %s transform", this->static_gps_frame.c_str());
+            return;
+        }
+        this->gps_frame_established = true;
+    }
+
+    // Then check if we can initialize
+    if (this->map_frame_established && this->gps_frame_established)
+    {
+        if (ins_status == "INS_SOLUTION_GOOD")
+        {
+            this->initialized = true;
+            ROS_INFO("Localizer initialized");
+        }
+        else
+        {
+            ROS_WARN_THROTTLE(2, "Waiting for good INS solution");
+        }
+    }
+
+    if (!this->initialized)
+    {
+        ROS_WARN_THROTTLE(2, "Data received, but not ready to initialize");
+    }
+}
+
+tf2::Transform GpsInsLocalizerNl::convertLLHtoECEF(double latitude, double longitude, double height)
+{
+    // This function is inspired by:
+    // https://github.com/wavelab/libwave/tree/master/wave_geography
+
+    GeographicLib::Geocentric earth = GeographicLib::Geocentric::WGS84();
+
+    std::vector<double> rotation_vec(9, 0.0);
+    double x, y, z;
+    earth.Forward(latitude, longitude, height, x, y, z, rotation_vec);
+
+    tf2::Vector3 origin(x, y, z);
+    tf2::Matrix3x3 rotation;
+
+    rotation.setValue(
+        rotation_vec[0],
+        rotation_vec[1],
+        rotation_vec[2],
+        rotation_vec[3],
+        rotation_vec[4],
+        rotation_vec[5],
+        rotation_vec[6],
+        rotation_vec[7],
+        rotation_vec[8]);
+
+    tf2::Transform ecef_enu_tf(rotation, origin);
+    return ecef_enu_tf;
+}
+
+tf2::Quaternion GpsInsLocalizerNl::convertAzimuthToENU(double roll, double pitch, double yaw)
+{
+    // Convert from Azimuth (CW from North) to ENU (CCW from East)
+    yaw = -yaw + M_PI / 2;
+    // yaw = -yaw;
+
+    // Clamp within 0 to 2 pi
+    if (yaw > 2 * M_PI)
+    {
+        yaw = yaw - 2 * M_PI;
+    }
+    else if (yaw < 0)
+    {
+        yaw = yaw + 2 * M_PI;
+    }
+
+    // Novatel GPS uses different vehicle body frame (y forward, x right, z up)
+    pitch = -pitch;
+
+    // Broadcast map -> gps_measured tf
+    tf2::Quaternion orientation;
+    orientation.setRPY(roll, pitch, yaw);
+
+    return orientation;
+}
+
+}  // namespace gpsins_localizer
+
+PLUGINLIB_DECLARE_CLASS(gpsins_localizer,
+                        GpsInsLocalizerNl,
+                        gpsins_localizer::GpsInsLocalizerNl,
+                        nodelet::Nodelet);

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
@@ -1,18 +1,8 @@
 /*
-* AutonomouStuff ("COMPANY") CONFIDENTIAL
 * Unpublished Copyright (c) 2009-2019 AutonomouStuff, All Rights Reserved.
 *
-* NOTICE:  All information contained herein is, and remains the property of COMPANY. The intellectual and technical concepts contained
-* herein are proprietary to COMPANY and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law.
-* Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained
-* from COMPANY.  Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees, managers or contractors who have executed
-* Confidentiality and Non-disclosure agreements explicitly covering such access.
-*
-* The copyright notice above does not evidence any actual or intended publication or disclosure  of  this source code, which includes
-* information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.   ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
-* OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT  THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE
-* LAWS AND INTERNATIONAL TREATIES.  THE RECEIPT OR POSSESSION OF  THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS
-* TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+* This file is part of the gpsins_localizer which is released under the MIT license.
+* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
 */
 
 #include "gpsins_localizer/gpsins_localizer_nodelet.hpp"

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
@@ -276,7 +276,6 @@ tf2::Quaternion GpsInsLocalizerNl::convertAzimuthToENU(double roll, double pitch
 {
     // Convert from Azimuth (CW from North) to ENU (CCW from East)
     yaw = -yaw + M_PI / 2;
-    // yaw = -yaw;
 
     // Clamp within 0 to 2 pi
     if (yaw > 2 * M_PI)

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/test/rostest_integration_test.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/test/rostest_integration_test.cpp
@@ -1,0 +1,146 @@
+/*
+* AutonomouStuff ("COMPANY") CONFIDENTIAL
+* Unpublished Copyright (c) 2009-2019 AutonomouStuff, All Rights Reserved.
+*
+* NOTICE:  All information contained herein is, and remains the property of COMPANY. The intellectual and technical concepts contained
+* herein are proprietary to COMPANY and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law.
+* Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained
+* from COMPANY.  Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees, managers or contractors who have executed
+* Confidentiality and Non-disclosure agreements explicitly covering such access.
+*
+* The copyright notice above does not evidence any actual or intended publication or disclosure  of  this source code, which includes
+* information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.   ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
+* OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT  THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE
+* LAWS AND INTERNATIONAL TREATIES.  THE RECEIPT OR POSSESSION OF  THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS
+* TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+*/
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <novatel_gps_msgs/Inspva.h>
+#include <sensor_msgs/Imu.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/TwistStamped.h>
+#include <geometry_msgs/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+class NodeTest : public ::testing::Test
+{
+protected:
+    NodeTest() : tf_listener(this->tf_buffer) {}
+
+    ros::NodeHandle nh;
+
+    // Publishers
+    ros::Publisher inspva_pub =
+      nh.advertise<novatel_gps_msgs::Inspva>("/gps/inspva", 1, true);
+    ros::Publisher imu_pub =
+      nh.advertise<sensor_msgs::Imu>("/gps/imu", 1, true);
+
+    // Listen to TFs to ensure they are correct
+    tf2_ros::Buffer tf_buffer;
+    tf2_ros::TransformListener tf_listener;
+
+    // To be used for cartesian coordinates in meters, not LLH comparison
+    double error_bound = 0.001;
+
+    void SetUp() override
+    {
+        ros::spinOnce();
+    }
+
+    void sendInspvaMsg(double lat, double lon, double hgt, double roll, double pitch, double azimuth)
+    {
+        novatel_gps_msgs::Inspva output_msg;
+        output_msg.header.frame_id = "imu";
+        output_msg.header.stamp = ros::Time(0.1);
+        output_msg.status = "INS_SOLUTION_GOOD";
+        output_msg.latitude = lat;
+        output_msg.longitude = lon;
+        output_msg.height = hgt;
+        output_msg.roll = roll;
+        output_msg.pitch = pitch;
+        output_msg.azimuth = azimuth;
+
+        sendInspvaMsg(output_msg);
+    }
+
+    void sendInspvaMsg(novatel_gps_msgs::Inspva output_msg)
+    {
+        this->inspva_pub.publish(output_msg);
+        ros::spinOnce();
+    }
+
+    void sendImuMsg(double w_x, double w_y, double w_z)
+    {
+        sensor_msgs::Imu output_msg;
+        output_msg.header.frame_id = "imu";
+        output_msg.header.stamp = ros::Time(0.1);
+        output_msg.angular_velocity.x = w_x;
+        output_msg.angular_velocity.y = w_y;
+        output_msg.angular_velocity.z = w_z;
+
+        this->imu_pub.publish(output_msg);
+        ros::spinOnce();
+    }
+
+    void compareTF(geometry_msgs::Transform actual_tf,
+        double t_x, double t_y, double t_z, double r_x, double r_y, double r_z, double r_w)
+    {
+        EXPECT_NEAR(actual_tf.translation.x, t_x, this->error_bound);
+        EXPECT_NEAR(actual_tf.translation.y, t_y, this->error_bound);
+        EXPECT_NEAR(actual_tf.translation.z, t_z, this->error_bound);
+        EXPECT_NEAR(actual_tf.rotation.x, r_x, this->error_bound);
+        EXPECT_NEAR(actual_tf.rotation.y, r_y, this->error_bound);
+        EXPECT_NEAR(actual_tf.rotation.z, r_z, this->error_bound);
+        EXPECT_NEAR(actual_tf.rotation.w, r_w, this->error_bound);
+    }
+};
+
+TEST_F(NodeTest, mapFrameTest)
+{
+    // Test to ensure the map frame is created properly
+    this->sendInspvaMsg(40.6117970767, -89.4833445072, 186.867369233, 0, 0, 0);
+    this->sendImuMsg(0, 0, 0);
+    ros::Duration(1.0).sleep();
+
+    auto earth_map_tf = this->tf_buffer.lookupTransform("earth", "map", ros::Time(0));
+
+    compareTF(earth_map_tf.transform, 43723.6310494, -4848708.00343, 4129913.74802,
+    0.417769295391, 0.0018835965371, 0.00409634337214, 0.908541957129);
+}
+
+TEST_F(NodeTest, tfTreeTest)
+{
+    // This test is to ensure that the base_link -> map tf was updated properly
+
+    // Push through two msgs to make sure it is initialized
+    this->sendInspvaMsg(40.6117970767, -89.4833445072, 186.867369233, 0.1, 0.86, 2.5);
+    this->sendImuMsg(0, 0, 0);
+    ros::Duration(1.0).sleep();
+    this->sendInspvaMsg(40.6117970767, -89.4833445072, 186.867369233, 0.1, 0.86, 2.5);
+    this->sendImuMsg(0, 0, 0);
+
+    auto earth_gps_tf = this->tf_buffer.lookupTransform("earth", "imu", ros::Time(0), ros::Duration(3.0));
+    auto earth_gpsm_tf = this->tf_buffer.lookupTransform("earth", "gps_measured", ros::Time(0), ros::Duration(3.0));
+
+    compareTF(earth_gpsm_tf.transform,
+        earth_gps_tf.transform.translation.x,
+        earth_gps_tf.transform.translation.y,
+        earth_gps_tf.transform.translation.z,
+        earth_gps_tf.transform.rotation.x,
+        earth_gps_tf.transform.rotation.y,
+        earth_gps_tf.transform.rotation.z,
+        earth_gps_tf.transform.rotation.w);
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    ros::init(argc, argv, "test_gpsins_localizer_node");
+    return RUN_ALL_TESTS();
+}

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/test/rostest_integration_test.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/test/rostest_integration_test.cpp
@@ -1,18 +1,8 @@
 /*
-* AutonomouStuff ("COMPANY") CONFIDENTIAL
 * Unpublished Copyright (c) 2009-2019 AutonomouStuff, All Rights Reserved.
 *
-* NOTICE:  All information contained herein is, and remains the property of COMPANY. The intellectual and technical concepts contained
-* herein are proprietary to COMPANY and may be covered by U.S. and Foreign Patents, patents in process, and are protected by trade secret or copyright law.
-* Dissemination of this information or reproduction of this material is strictly forbidden unless prior written permission is obtained
-* from COMPANY.  Access to the source code contained herein is hereby forbidden to anyone except current COMPANY employees, managers or contractors who have executed
-* Confidentiality and Non-disclosure agreements explicitly covering such access.
-*
-* The copyright notice above does not evidence any actual or intended publication or disclosure  of  this source code, which includes
-* information that is confidential and/or proprietary, and is a trade secret, of  COMPANY.   ANY REPRODUCTION, MODIFICATION, DISTRIBUTION, PUBLIC  PERFORMANCE,
-* OR PUBLIC DISPLAY OF OR THROUGH USE  OF THIS  SOURCE CODE  WITHOUT  THE EXPRESS WRITTEN CONSENT OF COMPANY IS STRICTLY PROHIBITED, AND IN VIOLATION OF APPLICABLE
-* LAWS AND INTERNATIONAL TREATIES.  THE RECEIPT OR POSSESSION OF  THIS SOURCE CODE AND/OR RELATED INFORMATION DOES NOT CONVEY OR IMPLY ANY RIGHTS
-* TO REPRODUCE, DISCLOSE OR DISTRIBUTE ITS CONTENTS, OR TO MANUFACTURE, USE, OR SELL ANYTHING THAT IT  MAY DESCRIBE, IN WHOLE OR IN PART.
+* This file is part of the gpsins_localizer which is released under the MIT license.
+* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
 */
 
 #include <gtest/gtest.h>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/test/rostest_launch.test
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/test/rostest_launch.test
@@ -1,0 +1,15 @@
+<launch>
+    <include file="$(find gpsins_localizer)/launch/gpsins_localizer_node.launch" />
+    <rosparam ns="gpsins_localizer">
+        create_map_frame: true
+        publish_earth_gpsm_tf: true
+    </rosparam>
+
+    <!-- Static TF -->
+    <node pkg="tf2_ros" type="static_transform_publisher" name="base_link_to_imu" args="
+        0.3 -0.5 0.4
+        0.0 0.0 0.0
+        base_link imu" />
+
+    <test test-name="GpsInsLocalizerNodeTest" pkg="gpsins_localizer" type="test_gpsins_localizer_node" time-limit="30.0"/>
+</launch>


### PR DESCRIPTION
This PR adds the `gpsins_localizer` node. It is a stand-alone replacement of ndt_matching that uses gps-ins data only. At the moment it only supports data coming from the [novatel_gps_driver](https://github.com/swri-robotics/novatel_gps_driver).
In the future (once autoware gets an EKF), hopefully this package can be more closely integrated with existing localization methods within autoware.

## Todos
- [x] In-vehicle testing.

## Steps to Test or Reproduce
You will need a static base_link -> imu tf defined before testing the node. 
You should be able to localize with default settings by running:
```
roslaunch gpsins_localizer gpsins_localizer_node.launch
```