### PR TITLE
Initialize without INS solution

### DIFF
--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
@@ -6,13 +6,17 @@ ins_data_topic_name: gps/inspva
 
 # Enable this to "plant" the origin of the map frame at the first received LLH
 # position. If an existing map frame is defined, this should not be set.
-create_map_frame: true
+create_map_frame: false
 
 # Enable if you want to directly publish the measured earth -> gps TF
-publish_earth_gpsm_tf: true
+publish_earth_gpsm_tf: false
 # The name of the measured GPS frame
 measured_gps_frame: gps_measured
 
 # The frame name of the gps sensor, Novatel SPAN devices report data in the imu
 # frame
 static_gps_frame: imu
+
+# Initialize without waiting for "INS_SOLUTION_GOOD" status from the Novatel
+# Use at your own risk
+no_solution_init: false

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
@@ -84,6 +84,7 @@ class GpsInsLocalizerNl : public nodelet::Nodelet {
     bool publish_earth_gpsm_tf = false;
     std::string measured_gps_frame = "gps_measured";
     std::string static_gps_frame = "gps";
+    bool no_solution_init = false;
 };
 
 }  // namespace gpsins_localizer

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
@@ -227,14 +227,34 @@ void GpsInsLocalizerNl::checkInitialize(std::string ins_status)
     // Then check if we can initialize
     if (this->map_frame_established && this->gps_frame_established)
     {
-        if (ins_status == "INS_SOLUTION_GOOD" || this->no_solution_init)
+        bool ins_alignment_complete = false;
+        bool ins_solution_good = false;
+        if (ins_status == "INS_ALIGNMENT_COMPLETE")
+        {
+            ins_alignment_complete = true;
+        }
+        if (ins_status == "INS_SOLUTION_GOOD")
+        {
+            ins_alignment_complete = true;
+            ins_solution_good = true;
+        }
+        if (this->no_solution_init)
+        {
+            ins_solution_good = true;
+        }
+
+        if (ins_alignment_complete && ins_solution_good)
         {
             this->initialized = true;
             ROS_INFO("Localizer initialized");
         }
+        else if (!ins_solution_good)
+        {
+            ROS_WARN_THROTTLE(2, "Waiting for INS_SOLUTION_GOOD status");
+        }
         else
         {
-            ROS_WARN_THROTTLE(2, "Waiting for good INS solution");
+            ROS_WARN_THROTTLE(2, "Waiting for INS_ALIGNMENT_COMPLETE status");
         }
     }
 

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
@@ -48,6 +48,7 @@ void GpsInsLocalizerNl::loadParams()
     this->pnh.param("publish_earth_gpsm_tf", this->publish_earth_gpsm_tf, false);
     this->pnh.param<std::string>("measured_gps_frame", this->measured_gps_frame, "gps_measured");
     this->pnh.param<std::string>("static_gps_frame", this->static_gps_frame, "gps");
+    this->pnh.param("no_solution_init", this->no_solution_init, false);
     ROS_INFO("Parameters Loaded");
 }
 
@@ -226,7 +227,7 @@ void GpsInsLocalizerNl::checkInitialize(std::string ins_status)
     // Then check if we can initialize
     if (this->map_frame_established && this->gps_frame_established)
     {
-        if (ins_status == "INS_SOLUTION_GOOD")
+        if (ins_status == "INS_SOLUTION_GOOD" || this->no_solution_init)
         {
             this->initialized = true;
             ROS_INFO("Localizer initialized");


### PR DESCRIPTION
This PR adds a parameter to allow the localizer to initialize without waiting for INS_SOLUTION_GOOD.
We found this useful during times when the Novatel was taking a long time to init even though it had acceptable stddevs. 

Ideally, the localizer should be constantly monitoring the data std deviations during operation, but that's a feature that can be added later as needed. This small addition works fine for now.

I also disabled some other params by default to better reflect normal operating parameters.