### PR TITLE
Temporarily disabling turn signal control through SSC.

### DIFF
--- a/ros/src/actuation/vehicles/packages/as/nodes/ssc_interface/ssc_interface.cpp
+++ b/ros/src/actuation/vehicles/packages/as/nodes/ssc_interface/ssc_interface.cpp
@@ -276,7 +276,7 @@ void SSCInterface::publishCommand()
   // publish
   speed_mode_pub_.publish(speed_mode);
   steer_mode_pub_.publish(steer_mode);
-  turn_signal_pub_.publish(turn_signal);
+  // turn_signal_pub_.publish(turn_signal);
   gear_pub_.publish(gear_cmd);
 
   ROS_INFO_STREAM("Mode: " << (int)desired_mode << ", "


### PR DESCRIPTION
Due to the complexity of implementing our own turn signal control rules (specifically at intersections), this PR disables the publishing of TurnSignalCmd messages through SSC. This keeps the turn signal system disabled which allows the driver to manually control the turn signals.