### PR TITLE
gpsins_localizer MGRS mode

### DIFF
--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
@@ -16,3 +16,6 @@ measured_gps_frame: gps_measured
 # The frame name of the gps sensor, Novatel SPAN devices report data in the imu
 # frame
 static_gps_frame: imu
+
+# Enable to localize in MGRS coordinates
+mgrs_mode: true

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
@@ -21,4 +21,7 @@ static_gps_frame: imu
 # localizes in an existing map frame that presumably represents the nearest
 # MGRS origin. The "create_map_frame" and "publish_earth_gpsm_tf" parameters
 # have no effect if mgrs_mode is enabled.
+# WARNING: if the MGRS zone changes during operation, the localizer will freeze
+# in place, only use this mode if you are certain you will be operating in the
+# same MGRS zone throughout.
 mgrs_mode: false

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
@@ -21,4 +21,4 @@ static_gps_frame: imu
 # localizes in an existing map frame that presumably represents the nearest
 # MGRS origin. The "create_map_frame" and "publish_earth_gpsm_tf" parameters
 # have no effect if mgrs_mode is enabled.
-mgrs_mode: true
+mgrs_mode: false

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/config/params.yaml
@@ -17,5 +17,8 @@ measured_gps_frame: gps_measured
 # frame
 static_gps_frame: imu
 
-# Enable to localize in MGRS coordinates
+# MGRS mode is a simplified opertating mode that doesn't use ECEF and simply
+# localizes in an existing map frame that presumably represents the nearest
+# MGRS origin. The "create_map_frame" and "publish_earth_gpsm_tf" parameters
+# have no effect if mgrs_mode is enabled.
 mgrs_mode: true

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
@@ -79,6 +79,9 @@ class GpsInsLocalizerNl : public nodelet::Nodelet {
     bool initialized = false;
     bool map_frame_established = false;
     bool gps_frame_established = false;
+    std::string mgrs_zone = "";
+    tf2::Transform prev_mgrs_pose;
+    bool mgrs_pose_frozen = false;
 
     // Parameters
     std::string imu_data_topic_name = "gps/imu";

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
@@ -44,6 +44,7 @@ class GpsInsLocalizerNl : public nodelet::Nodelet {
         const sensor_msgs::Imu::ConstPtr& imu_msg);
 
     // Util functions
+    void publishPose(tf2::Transform pose, ros::Time stamp);
     void pubishVelocity(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg,
         const sensor_msgs::Imu::ConstPtr& imu_msg);
     void createMapFrame(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg);
@@ -51,6 +52,7 @@ class GpsInsLocalizerNl : public nodelet::Nodelet {
     void checkInitialize(std::string ins_status);
     tf2::Transform convertLLHtoECEF(double latitude, double longitude, double height);
     tf2::Quaternion convertAzimuthToENU(double roll, double pitch, double yaw);
+    tf2::Transform convertLLHtoMGRS(double latitude, double longitude, double height, double roll, double pitch, double yaw);
 
     // Nodehandles, both public and private
     ros::NodeHandle nh, pnh;
@@ -84,6 +86,7 @@ class GpsInsLocalizerNl : public nodelet::Nodelet {
     bool publish_earth_gpsm_tf = false;
     std::string measured_gps_frame = "gps_measured";
     std::string static_gps_frame = "gps";
+    bool mgrs_mode = false;
 };
 
 }  // namespace gpsins_localizer

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/include/gpsins_localizer/gpsins_localizer_nodelet.hpp
@@ -44,15 +44,16 @@ class GpsInsLocalizerNl : public nodelet::Nodelet {
         const sensor_msgs::Imu::ConstPtr& imu_msg);
 
     // Util functions
+    void broadcastTf(tf2::Transform transform, ros::Time stamp);
     void publishPose(tf2::Transform pose, ros::Time stamp);
     void pubishVelocity(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg,
         const sensor_msgs::Imu::ConstPtr& imu_msg);
     void createMapFrame(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg);
-    void bcMeasuredGpsFrame(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg);
+    tf2::Transform calculateBaselinkPose(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg);
     void checkInitialize(std::string ins_status);
     tf2::Transform convertLLHtoECEF(double latitude, double longitude, double height);
     tf2::Quaternion convertAzimuthToENU(double roll, double pitch, double yaw);
-    tf2::Transform convertLLHtoMGRS(double latitude, double longitude, double height, double roll, double pitch, double yaw);
+    tf2::Transform convertECEFtoMGRS(tf2::Transform pose, double roll, double pitch, double yaw);
 
     // Nodehandles, both public and private
     ros::NodeHandle nh, pnh;

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/gpsins_localizer_node.launch
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/gpsins_localizer_node.launch
@@ -2,4 +2,9 @@
     <node pkg="gpsins_localizer" type="gpsins_localizer_node" name="gpsins_localizer" output="screen">
         <rosparam command="load" file="$(find gpsins_localizer)/config/params.yaml" />
     </node>
+
+    <node pkg="tf2_ros" type="static_transform_publisher" name="earth_to_map" args="
+        -1.2 1.4 0.5
+        0 0 0
+        base_link imu" />
 </launch>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/gpsins_localizer_node.launch
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/launch/gpsins_localizer_node.launch
@@ -2,9 +2,4 @@
     <node pkg="gpsins_localizer" type="gpsins_localizer_node" name="gpsins_localizer" output="screen">
         <rosparam command="load" file="$(find gpsins_localizer)/config/params.yaml" />
     </node>
-
-    <node pkg="tf2_ros" type="static_transform_publisher" name="earth_to_map" args="
-        -1.2 1.4 0.5
-        0 0 0
-        base_link imu" />
 </launch>

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
@@ -51,6 +51,15 @@ void GpsInsLocalizerNl::loadParams()
     this->pnh.param<std::string>("measured_gps_frame", this->measured_gps_frame, "gps_measured");
     this->pnh.param<std::string>("static_gps_frame", this->static_gps_frame, "gps");
     this->pnh.param("mgrs_mode", this->mgrs_mode, false);
+
+    // Simplified MGRS mode
+    if (this->mgrs_mode)
+    {
+        this->create_map_frame = false;
+        this->publish_earth_gpsm_tf = false;
+        this->map_frame_established = true;
+    }
+
     ROS_INFO("Parameters Loaded");
 }
 
@@ -60,7 +69,7 @@ void GpsInsLocalizerNl::insDataCb(
 {
     // We don't need any static TFs for this function, so no need to wait
     // for init
-    if (this->create_map_frame && !this->mgrs_mode)
+    if (this->create_map_frame)
     {
         createMapFrame(inspva_msg);
     }
@@ -175,7 +184,7 @@ tf2::Transform GpsInsLocalizerNl::calculateBaselinkPose(const novatel_gps_msgs::
     // Pose of base_link in earth_frame
     tf2::Transform baselink_earth = gpsm_earth * this->base_link_gps_tf;
 
-    if (this->publish_earth_gpsm_tf && !this->mgrs_mode)
+    if (this->publish_earth_gpsm_tf)
     {
         geometry_msgs::TransformStamped earth_gpsm_tf;
         earth_gpsm_tf.header.stamp = inspva_msg->header.stamp;

--- a/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
+++ b/ros/src/computing/perception/localization/packages/gpsins_localizer/src/gpsins_localizer_nodelet.cpp
@@ -11,6 +11,8 @@
 #include <vector>
 #include <math.h>
 #include <GeographicLib/Geocentric.hpp>
+#include <GeographicLib/UTMUPS.hpp>
+#include <GeographicLib/MGRS.hpp>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/TwistStamped.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -48,6 +50,7 @@ void GpsInsLocalizerNl::loadParams()
     this->pnh.param("publish_earth_gpsm_tf", this->publish_earth_gpsm_tf, false);
     this->pnh.param<std::string>("measured_gps_frame", this->measured_gps_frame, "gps_measured");
     this->pnh.param<std::string>("static_gps_frame", this->static_gps_frame, "gps");
+    this->pnh.param("mgrs_mode", this->mgrs_mode, false);
     ROS_INFO("Parameters Loaded");
 }
 
@@ -55,6 +58,33 @@ void GpsInsLocalizerNl::insDataCb(
     const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg,
     const sensor_msgs::Imu::ConstPtr& imu_msg)
 {
+    // MGRS mode is a simplified opertating mode that doesn't use ECEF and simply
+    // localizes in an existing map frame that presumably represents the nearest
+    // MGRS origin
+    if (this->mgrs_mode)
+    {
+        tf2::Transform base_link_map = convertLLHtoMGRS(
+            inspva_msg->latitude, inspva_msg->longitude, inspva_msg->height,
+            inspva_msg->roll * M_PI / 180,
+            inspva_msg->pitch * M_PI / 180,
+            inspva_msg->azimuth * M_PI / 180);
+
+        // Broadcast the map -> base_link transform
+        geometry_msgs::TransformStamped map_baselink_tf;
+        map_baselink_tf.header.frame_id = "map";
+        map_baselink_tf.child_frame_id = "base_link";
+        // map_baselink_tf.header.stamp = inspva_msg->header.stamp;
+        tf2::convert(base_link_map, map_baselink_tf.transform);
+        this->tf_bc.sendTransform(map_baselink_tf);
+
+        // Publish base_link pose in the map frame
+        publishPose(base_link_map, inspva_msg->header.stamp);
+        pubishVelocity(inspva_msg, imu_msg);
+
+        return;
+    }
+
+
     // We don't need any static TFs for these 2 functions, so no need to wait
     // for init
     if (this->create_map_frame)
@@ -101,14 +131,23 @@ void GpsInsLocalizerNl::insDataCb(
     this->tf_bc.sendTransform(map_baselink_tf);
 
     // Publish base_link pose in the map frame
-    geometry_msgs::PoseStamped base_link_map_stamped;
-    base_link_map_stamped.header.stamp = inspva_msg->header.stamp;
-    base_link_map_stamped.header.frame_id = "map";
-    tf2::toMsg(base_link_map, base_link_map_stamped.pose);
-    this->pose_pub.publish(base_link_map_stamped);
-
+    // geometry_msgs::PoseStamped base_link_map_stamped;
+    // base_link_map_stamped.header.stamp = inspva_msg->header.stamp;
+    // base_link_map_stamped.header.frame_id = "map";
+    // tf2::toMsg(base_link_map, base_link_map_stamped.pose);
+    // this->pose_pub.publish(base_link_map_stamped);
+    publishPose(base_link_map, inspva_msg->header.stamp);
     pubishVelocity(inspva_msg, imu_msg);
-    return;
+}
+
+void GpsInsLocalizerNl::publishPose(tf2::Transform pose, ros::Time stamp)
+{
+    // Publish pose in the map frame
+    geometry_msgs::PoseStamped pose_stamped;
+    pose_stamped.header.stamp = stamp;
+    pose_stamped.header.frame_id = "map";
+    tf2::toMsg(pose, pose_stamped.pose);
+    this->pose_pub.publish(pose_stamped);
 }
 
 void GpsInsLocalizerNl::pubishVelocity(const novatel_gps_msgs::Inspva::ConstPtr& inspva_msg,
@@ -270,6 +309,31 @@ tf2::Transform GpsInsLocalizerNl::convertLLHtoECEF(double latitude, double longi
 
     tf2::Transform ecef_enu_tf(rotation, origin);
     return ecef_enu_tf;
+}
+
+tf2::Transform GpsInsLocalizerNl::convertLLHtoMGRS(double latitude, double longitude, double height, double roll, double pitch, double yaw)
+{
+    int utm_zone;
+    bool utm_northp;
+    double utm_x, utm_y;
+    std::string mgrs_string;
+    // precision 8 represents millimetres
+    int precision = 8;
+
+    GeographicLib::UTMUPS::Forward(latitude, longitude, utm_zone, utm_northp, utm_x, utm_y);
+    GeographicLib::MGRS::Forward(utm_zone, utm_northp, utm_x, utm_y, latitude, precision, mgrs_string);
+
+    // Parse MGRS string to actually use it
+    tf2::Vector3 mgrs_point;
+    mgrs_point.setX(std::stod(mgrs_string.substr(mgrs_string.length() - precision * 2, precision)) / 1000);
+    mgrs_point.setY(std::stod(mgrs_string.substr(mgrs_string.length() - precision, precision)) / 1000);
+    mgrs_point.setZ(height);
+
+    tf2::Transform mgrs_pose;
+    mgrs_pose.setOrigin(mgrs_point);
+    mgrs_pose.setRotation(convertAzimuthToENU(roll, pitch, yaw));
+
+    return mgrs_pose;
 }
 
 tf2::Quaternion GpsInsLocalizerNl::convertAzimuthToENU(double roll, double pitch, double yaw)


### PR DESCRIPTION
This PR closes #17 by adding an MGRS operating mode.
This operating mode positions the vehicle in a map frame that represents the nearest MGRS origin. The reason for this functionality is to be able to work with autoware's non-standard frame convention. Currently the lanelet2 -> vectormap converter only produces maps in MGRS coordinates. Until the converter can be updated, this operating mode can be used to localize in MGRS.

Tested on rosbags and in-vehicle. During this update, I also did a bit of refactoring to make the code more generalized.

To test this localizer, all you should need to do is enable the mgrs_mode param and drive around manually (or playback rosbags) to see if the localization solution looks correct.

Also take note of the warning associated with this feature:
```
WARNING: if the MGRS zone changes during operation, the localizer will freeze in place, only use this mode if you are certain you will be operating in the same MGRS zone throughout.
```